### PR TITLE
Runner version update to v2.308.0

### DIFF
--- a/kustomization.yml
+++ b/kustomization.yml
@@ -94,7 +94,7 @@ patches:
 
 images:
 - name: summerwind/actions-runner
-  newTag: v2.307.0-ubuntu-20.04
+  newTag: v2.308.0-ubuntu-20.04
 - name: us.gcr.io/ridecell-1/ridecell-controllers
   newTag: 1643797148-bcf06cb2-main
 - name: k8s.gcr.io/autoscaling/cluster-autoscaler


### PR DESCRIPTION
Current Version: v2.307.0-ubuntu-20.04
Latest Release: v2.309.0
Previous Major Version: v2.308
Latest Release from Previous Major: v2.308.0